### PR TITLE
Refresh of your Salt+Consul Demo

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,8 +16,8 @@ end
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "virtualbox" do |vbox, override|
-    override.vm.box = "ubuntu/trusty64"
-    vbox.memory = 1024
+    override.vm.box = "debian/jessie64"
+    vbox.memory = 700
     vbox.cpus = 2
 
     # Enable multiple guest CPUs if available
@@ -35,7 +35,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     master.vm.provision "shell", inline: <<-SHELL
       sed -i '/127.0.1.1/d' /etc/hosts
       curl -L https://bootstrap.saltstack.com -o /tmp/install_salt.sh
-      sh /tmp/install_salt.sh -M -P git v2015.8.0
+      sh /tmp/install_salt.sh -M -P git v2016.11.3
     SHELL
   end
 
@@ -51,7 +51,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       node.vm.provision "shell", inline: <<-SHELL
         sed -i '/127.0.1.1/d' /etc/hosts
         curl -L https://bootstrap.saltstack.com -o /tmp/install_salt.sh
-        sh /tmp/install_salt.sh -P git v2015.8.0
+	sh /tmp/install_salt.sh -P git v2016.11.3
       SHELL
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 VAGRANTFILE_API_VERSION = "2"
 
-required_plugins = ["vagrant-hosts", "vagrant-hostmanager"]
+required_plugins = ["vagrant-hosts", "vagrant-hostmanager", "vagrant-vbguest"]
 required_plugins.each do |plugin|
   unless Vagrant.has_plugin?(plugin)
     # Attempt to install plugin. Bail out on failure to prevent an infinite loop.
@@ -16,12 +16,19 @@ end
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "virtualbox" do |vbox, override|
-    override.vm.box = "debian/jessie64"
-    vbox.memory = 700
-    vbox.cpus = 2
-
     # Enable multiple guest CPUs if available
+    override.vm.box = "debian/jessie64"
+    vbox.memory = 1024
+    vbox.cpus = 2
     vbox.customize ["modifyvm", :id, "--ioapic", "on"]
+  end
+
+  config.vm.provider "libvirt" do |lv, override|
+    # Enable multiple guest CPUs if available
+    override.vm.box = "debian/jessie64"
+    lv.memory = 1024
+    lv.cpus = 2
+    #lv.customize ["modifyvm", :id, "--ioapic", "on"]
   end
 
   config.vm.define "master" do |master|
@@ -34,6 +41,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
     master.vm.provision "shell", inline: <<-SHELL
       sed -i '/127.0.1.1/d' /etc/hosts
+      apt-get install -y curl
       curl -L https://bootstrap.saltstack.com -o /tmp/install_salt.sh
       sh /tmp/install_salt.sh -M -P git v2016.11.3
     SHELL
@@ -50,8 +58,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
       node.vm.provision "shell", inline: <<-SHELL
         sed -i '/127.0.1.1/d' /etc/hosts
+        apt-get install -y curl
         curl -L https://bootstrap.saltstack.com -o /tmp/install_salt.sh
-	sh /tmp/install_salt.sh -P git v2016.11.3
+        sh /tmp/install_salt.sh -P git v2016.11.3
       SHELL
     end
   end

--- a/salt/consul/consul.config
+++ b/salt/consul/consul.config
@@ -1,1 +1,14 @@
-{"acl_datacenter":"dc1","acl_master_token":"9abbcdd9-f410-4432-962f-1d4f4162068d","bootstrap_expect":1,"client_addr":"0.0.0.0","data_dir":"/opt/consul","datacenter":"dc1","encrypt":"twAZrmm4F801C+6tC7Funw==","log_level":"INFO","node_name":"salt-master","server":true,"ui_dir":"/opt/consul/dist"}
+{
+"acl_datacenter":"dc1",
+"acl_master_token":"9abbcdd9-f410-4432-962f-1d4f4162068d",
+"bootstrap_expect":1,
+"bind_addr":"{{ addr }}",
+"client_addr":"{{ addr }}",
+"data_dir":"/opt/consul",
+"datacenter":"dc1",
+"encrypt":"twAZrmm4F801C+6tC7Funw==",
+"log_level":"INFO",
+"node_name":"salt-master",
+"server":true,
+"ui_dir":"/opt/consul/dist"
+}

--- a/salt/consul/consul.default
+++ b/salt/consul/consul.default
@@ -1,0 +1,1 @@
+OPTIONS="-ui "

--- a/salt/consul/consul.service
+++ b/salt/consul/consul.service
@@ -1,14 +1,15 @@
-description "Consul"
+[Unit]
+Description=consul agent
+Requires=network-online.target
+After=network-online.target
 
-start on (net-device-up
-          and local-filesystems
-          and runlevel [2345])
-stop on runlevel [!2345]
-limit nofile 100000 100000
+[Service]
+EnvironmentFile=-/etc/default/consul
+Environment=GOMAXPROCS=2
+Restart=on-failure
+ExecStart=/usr/local/bin/consul agent $OPTIONS -config-dir=/etc/consul.d
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGINT
 
-script
-  # Read configuration variable file if it is present
-  [ -f /etc/default/$UPSTART_JOB ] && . /etc/default/$UPSTART_JOB
-
-  exec consul agent -config-dir /etc/consul
-end script
+[Install]
+WantedBy=multi-user.target

--- a/salt/consul/init.sls
+++ b/salt/consul/init.sls
@@ -12,31 +12,39 @@ consul_prereq:
     - watch:
       - file: /tmp/install_consul.sh
 
-/etc/consul:
+/etc/consul.d:
   file.directory:
     - user: root
     - group: root
     - dir_mode: 755
 
-/etc/consul/config.json:
+/etc/consul.d/config.json:
   file.managed:
     - source: salt://consul/consul.config
+    - template: jinja
     - require:
-      - file: /etc/consul
+      - file: /etc/consul.d
+    - defaults:
+        addr: {{ grains['ip4_interfaces']['eth1'][0] }}
 
-/etc/init/consul.conf:
+/etc/default/consul:
+  file.managed:
+    - source: salt://consul/consul.default
+
+/etc/systemd/system/consul.service:
   file.managed:
     - source: salt://consul/consul.service
     - require:
       - cmd: /tmp/install_consul.sh
-      - file: /etc/consul/config.json
+      - file: /etc/consul.d/config.json
+      - file: /etc/default/consul
 
 consul:
   service.running:
     - enable: True
     - reload: True
     - watch:
-      - file: /etc/consul/config.json
+      - file: /etc/consul.d/config.json
       - cmd: /tmp/install_consul.sh
 
 python-pip:

--- a/salt/consul/install_consul.sh
+++ b/salt/consul/install_consul.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-curl -L https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip -o /tmp/0.5.2_linux_amd64.zip
-unzip -d /usr/local/bin/ /tmp/0.5.2_linux_amd64.zip
+curl -L https://releases.hashicorp.com/consul/0.7.5/consul_0.7.5_linux_amd64.zip -o /tmp/consul_0.7.5_linux_amd64.zip
+unzip -d /usr/local/bin/ /tmp/consul_0.7.5_linux_amd64.zip
 chmod a+x /usr/local/bin/consul
-curl -L https://dl.bintray.com/mitchellh/consul/0.5.2_web_ui.zip -o /tmp/0.5.2_web_ui.zip
-mkdir -p /opt/consul
-unzip -d /opt/consul /tmp/0.5.2_web_ui.zip


### PR DESCRIPTION
Hello,

I tried to refresh your demo a bit:
+ Based on debian jessie64
+ libvirt support
+ Install latest salt and consul release
+ Update consul init script to systemd
+ Get a workaround on a new consul behavior that enforce to bind on one only ip address.